### PR TITLE
Add usb storage calls

### DIFF
--- a/include/usb_storage.h
+++ b/include/usb_storage.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "prerequisites.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	struct SceUsbStorageDeviceInfo
+	{
+		uint64_t totalSpace;
+		uint64_t availableSpace;
+		uint16_t vendorId;
+		uint16_t productId;
+		uint16_t bcdDevice;
+		char manufacturer[256];
+		uint64_t manufacturerLength;
+		char product[256];
+		uint64_t productLength;
+		char serialNumber[256];
+		uint64_t serialNumberLength;
+		uint64_t additionalFeatures;
+		uint64_t capacity;
+	};
+
+
+	// int32_t sceUsbStorageIsExist(uint32_t, const char*);
+	// int32_t sceUsbStorageRegisterCallback(uint32_t, ...);
+	// int32_t sceUsbStorageUnregisterCallback(uint32_t, ...);
+
+	int32_t sceUsbStorageGetDeviceInfo(uint32_t, SceUsbStorageDeviceInfo *);
+	int32_t sceUsbStorageGetDeviceList(uint32_t*, int32_t*);
+	int32_t sceUsbStorageInit(ScePthreadAttr *);
+	int32_t sceUsbStorageRequestMap(uint32_t, const char *, int32_t, uint64_t, char *, uint64_t *, const void *, size_t);
+	int32_t sceUsbStorageRequestMapWSB(uint32_t, const char *, int32_t, uint64_t, char *, uint64_t *, const void *, size_t);
+	int32_t sceUsbStorageRequestUnmap(uint32_t, const char *, const void *, size_t);
+	int32_t sceUsbStorageTerm();
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/libSceUsbStorage/Makefile
+++ b/lib/libSceUsbStorage/Makefile
@@ -1,0 +1,1 @@
+-include ../stub.mk

--- a/lib/libSceUsbStorage/libSceUsbStorage.def
+++ b/lib/libSceUsbStorage/libSceUsbStorage.def
@@ -1,0 +1,10 @@
+fun:
+	sceUsbStorageGetDeviceInfo
+	sceUsbStorageGetDeviceList
+	sceUsbStorageInit
+	sceUsbStorageIsExist
+	sceUsbStorageRegisterCallback
+	sceUsbStorageRequestMap
+	sceUsbStorageRequestUnmap
+	sceUsbStorageTerm
+	sceUsbStorageUnregisterCallback

--- a/lib/libSceUsbStorage/libSceUsbStorageAux.def
+++ b/lib/libSceUsbStorage/libSceUsbStorageAux.def
@@ -1,0 +1,2 @@
+fun:
+	sceUsbStorageRequestMapWSB


### PR DESCRIPTION
I noticed the requestMap function fails in Shellcore that causes mount to fail, if app category is not `(app_cat | 1) == 5` (aka app_cat == 4 or 5) or if skip param flag is not set.
P.S one of the valid app cat is gdd, the 2nd one is probably gdi (what the media app use, but app fails to launch using that)

however there is an unexported/No NID call that set the skip param which I access like this.

```C
	#define SCE_SYSMODULE_USB_STORAGE 0xD5

	int ret = sceSysmoduleLoadModule(SCE_SYSMODULE_USB_STORAGE);
	if (ret != SCE_OK) {
		printf("Error: sceSysmoduleLoadModule(SCE_SYSMODULE_USB_STORAGE), ret 0x%08x\n", ret);
		return ret;
	}
	typedef int32_t (*__sceUsbStorageRequestMap2)(uint32_t id, const char * directory, const char * mountpt);
	ret = sceUsbStorageInit(0);
	int32_t device_count = 0;
	uint32_t device_ids[10] = {0};
	sceUsbStorageGetDeviceList(device_ids, &device_count);
	__sceUsbStorageRequestMap2 _sceUsbStorageRequestMap2 = (__sceUsbStorageRequestMap2)(((uint64_t)&(*sceUsbStorageRequestMap)) - (0xF0 - 0x50)); // offset on 5.05

	for(int i = 0; i < device_count; ++i )
	{
		std::string mount_pt = std::string("/usb") + std::to_string(i);
		ret = _sceUsbStorageRequestMap2(device_ids[i],"/", mount_pt.c_str());
	}
```
if someone finds a none hack solution, I'd love to hear about it.

side note you can also get usb to work by patching `sceUsbStorageRequestMapWSB()`, this function calls 1 other function but adds 2 more arugments, the 1st new argument, aka argument (?) 8-9, can be patched from 3 to 2 and should have the same effect.